### PR TITLE
feat: adding state change queue

### DIFF
--- a/examples/application.sh
+++ b/examples/application.sh
@@ -84,3 +84,11 @@ function application::example::step_five() {
     sleep 1
     echo "Authorizing..."
 }
+
+function application::example::update_backtitle() {
+    local key=$1
+    [ "$key" = "name" ] &&
+    json_source="$(wheel::json::set "$json_source" "dialog.backtitle" "New Title - $(date)")"
+}
+
+wheel::events::add_state_change application::example::update_backtitle

--- a/test/state.bats
+++ b/test/state.bats
@@ -5,6 +5,7 @@ setup() {
     wheel::test::setup
     . wheel/constants.sh
     . wheel/state/module.sh
+    . wheel/events/module.sh
     . wheel/log/module.sh
 }
 

--- a/wheel/events/module.sh
+++ b/wheel/events/module.sh
@@ -2,6 +2,7 @@
 
 ACTIVE_DIALOG=""
 CLEANUP_QUEUE=()
+STATE_CHANGE_QUEUE=()
 
 function wheel::events::trap_exit() {
     # TODO: properly handle gauges
@@ -24,6 +25,25 @@ function wheel::events::add_clean_up() {
     local action=$1
     wheel::log::debug "Adding $action to clean-up"
     CLEANUP_QUEUE+=("$action")
+}
+
+function wheel::events::add_state_change() {
+    local action=$1
+    wheel::log::debug "Adding $action to state-change"
+    STATE_CHANGE_QUEUE+=("$action")
+}
+
+function wheel::events::fire() {
+    local event_name=$1
+    shift
+    command -v "wheel::events::$event_name" > /dev/null && "wheel::events::$event_name" "$@"
+}
+
+function wheel::events::state_change() {
+    for action in "${STATE_CHANGE_QUEUE[@]}"; do
+        "$action" "$@"
+        wheel::log::info "Invoked '$action' with exit code $?"
+    done
 }
 
 function wheel::events::clean_up() {

--- a/wheel/state/module.sh
+++ b/wheel/state/module.sh
@@ -37,17 +37,27 @@ function wheel::state::set() {
     local rest=("$@")
 
     local state
+    local previous_value
+    previous_value=$(wheel::json::get "$APP_STATE" "$key")
     state=$(wheel::json::set "$APP_STATE" "$key" "$value" "${rest[@]}") || return $?
     wheel::log::debug "Setting state to: $state"
     APP_STATE=$state
+    if [ "$previous_value" != "$(wheel::json::get "$state" "$key")" ]; then
+        wheel::events::fire "state_change" "$key" "$previous_value"
+    fi
 }
 
 function wheel::state::del() {
     local key=$1
     local state
+    local previous_value
+    previous_value=$(wheel::json::get "$APP_STATE" "$key")
     state=$(wheel::json::del "$APP_STATE" "$key") || return $?
     wheel::log::debug "Setting state to: $state"
     APP_STATE=$state
+    if [ "$previous_value" != "$(wheel::json::get "$state" "$key")" ]; then
+        wheel::events::fire "state_change" "$key" "$previous_value"
+    fi
 }
 
 function wheel::state::interpolate() {


### PR DESCRIPTION
- Adding a new queue for processing state change events
- This is useful to dynamically change the way things are rendered (`dialog.backtitle` in the examples)